### PR TITLE
Allow users to use KMS key to crypt/decrypt S3 key content

### DIFF
--- a/kms-tfstates.tf
+++ b/kms-tfstates.tf
@@ -41,7 +41,7 @@ data "aws_iam_policy_document" "kms_tfstate_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${var.administrators}"]
+      identifiers = ["${var.administrators}", "${var.users}"]
     }
 
     actions = [


### PR DESCRIPTION
It's seems that users from `users` list cannot perform terraform operations (s3/putObject) because content cannot be crypted.

Allowing theses users to encrypt/decrypt made it work.